### PR TITLE
Bug fix php 8.0 Moodle 4.0.4

### DIFF
--- a/edit_metadata.php
+++ b/edit_metadata.php
@@ -389,7 +389,10 @@ if ($mform->is_cancelled()) {
 
         $toform->coursetitle = $course->fullname;
         if (isset($course->summary)) {
-            $toform->teasertext['text'] = $course->summary;
+          // CHANGED tinjohn 20221208 given array is not valid and not necessary.
+          // Modified to single string.
+          // Error php 8.0 and Moodle 4.0.4 -> mysqli::real_escape_string(): Argument #1 ($string) must be of type string, array given.
+            $toform->teasertext = $course->summary;
         }
         if (isset($course->startdate)) {
             $toform->starttime = $course->startdate;


### PR DESCRIPTION
Error thrown: mysqli::real_escape_string(): Argument #1 ($string) must be of type string, array given when trying to open settings from within the course.